### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -1,5 +1,8 @@
 name: Docker Image CI
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: [ "main" ]


### PR DESCRIPTION
Potential fix for [https://github.com/Moohan/gartan_scraper_bot/security/code-scanning/1](https://github.com/Moohan/gartan_scraper_bot/security/code-scanning/1)

To fix the problem, you should add a `permissions` block to the workflow to restrict the GITHUB_TOKEN to the least privilege required. In this case, since the workflow only checks out code and builds a Docker image, it only needs read access to repository contents. The best way to implement this is to add a `permissions` block at the root level of the workflow file (above `jobs:`), specifying `contents: read`. This will apply to all jobs in the workflow unless overridden. No additional imports or definitions are needed; simply add the block in the YAML file.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._

## Summary by Sourcery

CI:
- Add permissions block to GitHub Actions workflow to restrict GITHUB_TOKEN to contents: read