### PR TITLE
Potential fix for code scanning alert no. 11: Information exposure through an exception

### DIFF
--- a/api_server.py
+++ b/api_server.py
@@ -349,7 +349,7 @@ def health_check():
             jsonify(
                 {
                     "status": "unhealthy",
-                    "error": str(e),
+                    "error": "Internal server error",
                     "timestamp": datetime.now(timezone.utc).isoformat(),
                 }
             ),

--- a/api_server.py
+++ b/api_server.py
@@ -349,7 +349,7 @@ def health_check():
             jsonify(
                 {
                     "status": "unhealthy",
-                    "error": "Internal server error",
+                    "error": "Health check failed",
                     "timestamp": datetime.now(timezone.utc).isoformat(),
                 }
             ),


### PR DESCRIPTION
Potential fix for [https://github.com/Moohan/gartan_scraper_bot/security/code-scanning/11](https://github.com/Moohan/gartan_scraper_bot/security/code-scanning/11)

To fix the problem, we should avoid returning the exception message (`str(e)`) to the client in the JSON response. Instead, we should return a generic error message such as "Internal server error" or "Health check failed". The detailed exception information should continue to be logged on the server for debugging purposes. 

Specifically, in `api_server.py`, lines 350-352 should be changed so that the `"error"` field contains a generic message, not `str(e)`. No changes are needed to the logging statement. No new imports or methods are required.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._

## Summary by Sourcery

Bug Fixes:
- Return a generic “Internal server error” message instead of the raw exception text in the health_check JSON response

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - Health check endpoint now returns a generic error message (“Internal server error”) when an exception occurs, replacing the previous behaviour that exposed raw exception text. This prevents leaking internal details and ensures consistent, predictable responses for clients. HTTP status codes and other response fields are unchanged. No client-side changes are required.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->